### PR TITLE
Remove a problematic dependency from a sample test file (and cpanfile)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Acme::ReturnValue - report interesting return values
 
 # VERSION
 
-version 1.004
+version 1.005
 
 # SYNOPSIS
 

--- a/cpanfile
+++ b/cpanfile
@@ -38,7 +38,6 @@ on 'test' => sub {
   requires "Test::Most" => "0";
   requires "Time::Piece" => "0";
   requires "URI::file" => "0";
-  requires "WWW::Shorten::_dead" => "0";
   requires "XML::LibXML" => "0";
 };
 

--- a/t/pms/TinyClick.pm
+++ b/t/pms/TinyClick.pm
@@ -5,7 +5,6 @@ use strict;
 use warnings;
 
 our $VERSION = '1.90';
-require WWW::Shorten::_dead;
 
 0;
 


### PR DESCRIPTION
Hello,

It seems that WWW::Shorten::_dead is somewhat problematic since it is kind of "private" and not always resolved the same than WWW::Shorten (and can fail to build).

I think that it is used in this module only as part of a real world example (bundled code from another module) so I guess it is safe to just edit it and remove WWW::Shorten::_dead dependency.

Do you agree?
