### PR TITLE
exclude t/pms from prereq detection

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -24,28 +24,14 @@ on 'build' => sub {
 };
 
 on 'test' => sub {
-  requires "Acme::CPANAuthors::Register" => "0";
-  requires "Any::Moose" => "0";
-  requires "Carp" => "0";
-  requires "Digest::HMAC_SHA1" => "0";
-  requires "Exporter" => "0";
   requires "File::Spec" => "0";
   requires "File::Temp" => "0";
   requires "IO::Handle" => "0";
   requires "IPC::Open3" => "0";
-  requires "MIME::Base64" => "0";
   requires "Test::More" => "0";
   requires "Test::Most" => "0";
-  requires "Time::Piece" => "0";
-  requires "URI::file" => "0";
-  requires "WWW::Shorten::_dead" => "0";
-  requires "XML::LibXML" => "0";
 };
 
 on 'configure' => sub {
   requires "Module::Build" => "0.28";
-};
-
-on 'develop' => sub {
-  requires "Test::More" => "0";
 };

--- a/dist.ini
+++ b/dist.ini
@@ -8,6 +8,8 @@ copyright_year   = 2013 - 2021
 homepage = https://returnvalues.plix.at/
 Git::GatherDir.exclude_match[0] = returnvalues
 Git::GatherDir.exclude_match[1] = htdocs
-AutoPrereqs.skip[0] = RayApp
-AutoPrereqs.skip[1] = Does::Not::Exist
+AutoPrereqs.test_finder = MyTestFiles
 
+[FileFinder::Filter / MyTestFiles]
+finder = :TestFiles
+skip = t/pms/


### PR DESCRIPTION
The modules under t/pms/ are not really modules, but documents to read.
They are never loaded, and should not be scanned for prereqs.

Create a new file finder that excludes them, and use it for calculating
the test prerequisites.